### PR TITLE
Improve error handling in Monobase

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -47,8 +47,6 @@ const page = async (project: types.Project, page: string, root: string) => {
     chalk.gray(utils.fileSize(pageOutFullPath)),
     chalk.gray(`(${Math.round(Date.now() - time)}ms)`)
   );
-
-  return Promise.resolve();
 };
 
 export const favicon = async (project: types.Project, root) => {

--- a/src/build.ts
+++ b/src/build.ts
@@ -26,7 +26,7 @@ export const pages = async (project: types.Project, root: string) => {
         )}\n\n`
       );
       console.error(chalk.grey(error.stack));
-      process.exit();
+      process.exit(1);
     }
   }
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,11 +19,13 @@ import * as config from "./config";
 import * as cert from "./cert";
 
 process.on("unhandledRejection", (reason, p) => {
-  console.error("Unhandled Rejection at: Promise", p, "reason:", reason);
+  console.error("Unhandled Rejection at: Promise");
+  console.error(p);
+  exit(1);
 });
 
-const exit = () => {
-  process.exit();
+const exit = (code = 0) => {
+  process.exit(code);
 };
 
 const usage = () => {
@@ -98,10 +100,13 @@ const main = async () => {
     console.log(chalk.bgWhite.black(" MONOBASE "), chalk.green(url));
   } else if (command === "build") {
     const buildPath = argv.path || argv.p || path.join(project.path, "build");
-    commands.build(project, buildPath);
+    await commands.build(project, buildPath);
   } else {
     usage();
   }
 };
 
-main();
+main().catch(err => {
+  console.error(err);
+  exit(1);
+});

--- a/src/render.ts
+++ b/src/render.ts
@@ -28,9 +28,7 @@ export const page = async (project: types.Project, page: string) => {
   // An eval runtime could happen here
   const pageModule = compiler.module.default(project);
 
-  return new Promise((resolve, reject) => {
-    resolve(renderToString(pageModule));
-  });
+  return renderToString(pageModule);
 };
 
 export const script = async (project: types.Project) => {


### PR DESCRIPTION
A general summary of changes:

1) We now exit with non-zero code when error-ing during cli tasks. This means automated build systems like Netlify will halt the publishing flow if an error occurs. This does mean that unhandled promises in the monobase library will now bring down the server, I think this is acceptable.
2) We now support the async handlers in the express application. Any raised errors are currently being swallowed by the request handlers because express doesn't support promises. So we wrap the async handles in a function, catch any errors and pass them on to the next handler.
3) Re-works the Compiler module to raise errors when WebPack compilation fails. This will cause the build to fail and the server will return an appropriate 500 page with the stack. I've also swapped out the `_running` & `_resolvers` properties with a single `_result` promise that we just return from the `compile()` method.

Example 500 Page

<img width="1172" alt="screenshot 2019-02-07 at 12 09 42" src="https://user-images.githubusercontent.com/47144/52410753-470bd500-2ad1-11e9-9da3-98a96700cf6d.png">
  